### PR TITLE
Fix smach visualization in foxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 executive_smach_visualization [![Build Status](https://travis-ci.com/ros-visualization/executive_smach_visualization.svg?branch=melodic-devel)](https://travis-ci.com/ros-visualization/executive_smach_visualization)
 =====================================================================================================================================================================================================================
+
+## Installing Dependencies
+
+```bash
+# Installing system python-gi python-gi-cairo libgtk-3-dev
+sudo apt-get install -y python-gi python-gi-cairo python-wxversion libgtk-3-dev
+
+# Installing python3 wxpython graphviz
+pip3 install wxpython graphviz
+```

--- a/smach_viewer/CMakeLists.txt
+++ b/smach_viewer/CMakeLists.txt
@@ -10,11 +10,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-message(STATUS "Installing system python-gi python-gi-cairo libgtk-3-dev")
-execute_process(COMMAND apt-get install -y python-gi python-gi-cairo python-wxversion libgtk-3-dev)
-
-message(STATUS "Installing python3 wxpython graphviz")
-execute_process(COMMAND pip3 install wxpython graphviz)
+# message(STATUS "Installing system python-gi python-gi-cairo libgtk-3-dev")
+# execute_process(COMMAND apt-get install -y python-gi python-gi-cairo python-wxversion libgtk-3-dev)
+# 
+# message(STATUS "Installing python3 wxpython graphviz")
+# execute_process(COMMAND pip3 install wxpython graphviz)
 
 # find dependencies
 find_package(ament_cmake REQUIRED)

--- a/smach_viewer/CMakeLists.txt
+++ b/smach_viewer/CMakeLists.txt
@@ -10,12 +10,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# message(STATUS "Installing system python-gi python-gi-cairo libgtk-3-dev")
-# execute_process(COMMAND apt-get install -y python-gi python-gi-cairo python-wxversion libgtk-3-dev)
-# 
-# message(STATUS "Installing python3 wxpython graphviz")
-# execute_process(COMMAND pip3 install wxpython graphviz)
-
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)

--- a/smach_viewer/smach_viewer/smach_viewer_gui.py
+++ b/smach_viewer/smach_viewer/smach_viewer_gui.py
@@ -35,7 +35,7 @@ import rclpy
 from rclpy.time import Duration
 from rclpy.executors import SingleThreadedExecutor
 import rospkg
-import roslib
+# import roslib
 
 from smach_msgs.msg import (
     SmachContainerStatus,
@@ -182,7 +182,7 @@ class ContainerNode:
                 # This will only happen once for each package
                 modulename = ie.args[0][16:]
                 packagename = modulename[0 : modulename.find(".")]
-                roslib.load_manifest(packagename)
+                # roslib.load_manifest(packagename)
                 self._local_data._data = pickle.loads(msg.local_data)
 
         # Store the info string


### PR DESCRIPTION
### Description

Fix smach visualization in ROS2 foxy.
- Disable calls to outdated ROS1 roslib library.
   - This caused errors when trying to run the smach viewer.
- Disable calls to apt-get and pip3 in CMakeLists.txt.
   - Installation of dependencies while building is an unexpected side effect.
   - That also meant longer build times.

